### PR TITLE
Missing permission for RDS.4 execution.

### DIFF
--- a/source/lib/remediation_runbook-stack.ts
+++ b/source/lib/remediation_runbook-stack.ts
@@ -1033,7 +1033,8 @@ export class RemediationRunbookStack extends cdk.Stack {
         'rds:DescribeDBSnapshots',
         'rds:DescribeDBClusterSnapshots',
         'rds:DeleteDBSnapshot',
-        'rds:DeleteDBClusterSnapshots'
+        'rds:DeleteDBClusterSnapshots',
+        'rds:AddTagsToResource',
       );
       remediationPolicy.effect = Effect.ALLOW;
       remediationPolicy.addResources('*');


### PR DESCRIPTION
Issue #152

*Description of changes:*
- Added `rds:AddTagsToResource` permission to the remediation policy in `remediation_runbook-stack.ts`.
- The permission is necessary to allow the addition of tags to RDS resources as part of the remediation runbook process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.