### PR TITLE
fix: Improve the SHARR notification messages to include more relevant info for administrators receiving the events #185

### DIFF
--- a/source/lib/solution_deploy-stack.ts
+++ b/source/lib/solution_deploy-stack.ts
@@ -461,7 +461,7 @@ export class SolutionDeployStack extends cdk.Stack {
           resources: ['*'],
         }),
         new PolicyStatement({
-          actions: ['securityhub:BatchUpdateFindings'],
+          actions: ['securityhub:BatchUpdateFindings', 'securityhub:GetFindings'],
           resources: ['*'],
         }),
         new PolicyStatement({
@@ -475,6 +475,11 @@ export class SolutionDeployStack extends cdk.Stack {
         new PolicyStatement({
           actions: ['sns:Publish'],
           resources: [`arn:${this.partition}:sns:${this.region}:${this.account}:${RESOURCE_PREFIX}-SHARR_Topic`],
+        }),
+        // Allows conversion of Account Id -> Account Alias (Name)
+        new PolicyStatement({
+          actions: ['organizations:ListAccounts'],
+          resources: ['*'],
         }),
       ],
     });


### PR DESCRIPTION
*Issue #185 *

*Description of changes:*

Added additional properties to the Notification that is sent by SHARR on the SNS Topic when a Remediation is initiated and it's state changes.

re: Testing ...This patch was pulled from a custom branch that I have been running in production for months now.

Added Properties:
* `account_alias` - the alias of the `account_id` as returned from the `organizations.list_accounts` API
* `link` - and `http` link in the form `https://console.aws.amazon.com/securityhub/home?region={finding.region}#/findings?search={finding.id}'` that provides a quick link to the full finding details.
  * Clicking the link takes you to whatever AWS Account you are logged in with but if you login first to the right Account and then click the link it's still much faster than copy-pasting and searching the Finding ID/ARN
* `note` - the `Note` field from the Finding. This is found by looking up the Finding by it's ARN in Security Hub (`securityhub.get_findings`) and then reading the `Note.Text` value from it.
* `resource` - either the `AffectedObject` from the the Notification payload, or the Resource Id from the Finding. This is very helpful when a batch of remediations are run to identify quickly which resource the remediation was for.

*Permissions Changes*
* `securityhub:GetFindings`: required to lookup the Findings in Security Hub to get the Note off of it. 
  * There is a graceful fallback if the permission is not enabled which will log an INFO level message and leave the `note = ''` if there is any error in reading the finding. 
  * The permission is added in the `SolutionDeployStack` _specifically_ for the `SHARR_Orchestrator_Notifier` policy.
* `organizations:ListAccounts`: required to look up the Account Alias for the Account Id which is the target of the remediation. 
  * There is a graceful fallback if the permission is not enabled which will log a WARN level message and set the `account_alias` to the `account_id` value so it is never empty.
  * The permission is added in the `SolutionDeployStack` _specifically_ for the `SHARR_Orchestrator_Notifier` policy.

Example Notifications:
*Account Id changed to a dummy value for this comment*

```json
{
  "severity": "INFO",
  "message": "Remediation queued for SC control EC2.7 in account 123456789001",
  "finding": {
    "finding_id": "04f78bbd-e10f-4a3e-b473-63a561c7b002",
    "finding_description": "This control checks whether Amazon Elastic Block Store (EBS) encryption is enabled by default. The control fails if EBS default encryption is not enabled.",
    "standard_name": "security-control",
    "standard_version": "2.0.0",
    "standard_control": "EC2.7",
    "title": "EBS default encryption should be enabled",
    "region": "us-east-1",
    "account": "123456789001",
    "finding_arn": "arn:aws:securityhub:us-east-1:123456789001:security-control/EC2.7/finding/04f78bbd-e10f-4a3e-b473-63a561c7b002",
    "account_alias": "qcex-cloudformation-admin",
    "link": "https://console.aws.amazon.com/securityhub/home?region=us-east-1#/findings?search=Id%3D%255Coperator%255C%253AEQUALS%255C%253Aarn%253Aaws%253Asecurityhub%253Aus-east-1%253A123456789001%253Asecurity-control%252FEC2.7%252Ffinding%252F04f78bbd-e10f-4a3e-b473-63a561c7b002",
    "note": "",
    "resource": "123456789001"
  },
  "state": "QUEUED",
  "execution_id": "836c1d27-d8ca-44b2-8af0-11481cc2695c"
}
```

```json
{
  "severity": "INFO",
  "message": "Remediation succeeded for SC control EC2.7 in account 123456789001: Remediation status: Success - please verify remediation (AwsAccount AWS::::Account:123456789001)",
  "finding": {
    "finding_id": "04f78bbd-e10f-4a3e-b473-63a561c7b002",
    "finding_description": "This control checks whether Amazon Elastic Block Store (EBS) encryption is enabled by default. The control fails if EBS default encryption is not enabled.",
    "standard_name": "security-control",
    "standard_version": "2.0.0",
    "standard_control": "EC2.7",
    "title": "EBS default encryption should be enabled",
    "region": "us-east-1",
    "account": "123456789001",
    "finding_arn": "arn:aws:securityhub:us-east-1:123456789001:security-control/EC2.7/finding/04f78bbd-e10f-4a3e-b473-63a561c7b002",
    "account_alias": "qcex-cloudformation-admin",
    "link": "https://console.aws.amazon.com/securityhub/home?region=us-east-1#/findings?search=Id%3D%255Coperator%255C%253AEQUALS%255C%253Aarn%253Aaws%253Asecurityhub%253Aus-east-1%253A123456789001%253Asecurity-control%252FEC2.7%252Ffinding%252F04f78bbd-e10f-4a3e-b473-63a561c7b002",
    "note": "",
    "resource": "AWS::::Account:123456789001"
  },
  "state": "SUCCESS",
  "execution_id": "836c1d27-d8ca-44b2-8af0-11481cc2695c"
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.