### PR TITLE
release/v2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4] - 2024-11-18
+### Changed
+- Upgraded python runtimes in all control runbooks from python3.8 to python3.11.
+  - Upgrade is done at build-time temporarily, until the `cdklabs/cdk-ssm-documents` package adds support for newer python runtimes. 
+
 ## [2.1.3] - 2024-09-18
 
 ### Fixed

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -181,6 +181,8 @@ main() {
     mv "$template_dist_dir"/MemberRoleStack.template "$template_dist_dir"/aws-sharr-member-roles.template
 
     rm "$template_dist_dir"/*.nested.template
+
+    python3 $template_dir/upgrade_python_runtimes.py $template_dist_dir/playbooks
 }
 
 main "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automated_security_response_on_aws"
-version = "2.1.3"
+version = "2.1.4"
 
 [tool.setuptools]
 package-dir = {"" = "source"}

--- a/solution-manifest.yaml
+++ b/solution-manifest.yaml
@@ -1,6 +1,6 @@
 id: SO0111
 name: security-hub-automated-response-and-remediation
-version: 2.1.3
+version: 2.1.4
 cloudformation_templates:
   - template: aws-sharr-deploy.template
     main_template: true

--- a/source/package-lock.json
+++ b/source/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "automated-security-response-on-aws",
-    "version": "2.1.3",
+    "name": "aws-security-hub-automated-response-and-remediation",
+    "version": "2.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "automated-security-response-on-aws",
-            "version": "2.1.3",
+            "name": "aws-security-hub-automated-response-and-remediation",
+            "version": "2.1.4",
             "license": "Apache-2.0",
             "bin": {
                 "solution_deploy": "bin/solution_deploy.js"

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-security-hub-automated-response-and-remediation",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "Automated remediation for AWS Security Hub (SO0111)",
     "bin": {
         "solution_deploy": "bin/solution_deploy.js"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
## [2.1.4] - 2024-11-18
### Changed
- Upgraded python runtimes in all control runbooks from python3.8 to python3.11.
  - Upgrade is done at build-time temporarily, until the `cdklabs/cdk-ssm-documents` package adds support for newer python runtimes. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.