### PR TITLE
release/v2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4] - 2024-11-18
+### Changed
+- Upgraded python runtimes in all control runbooks from python3.8 to python3.11.
+  - Upgrade is done at build-time temporarily, until the `cdklabs/cdk-ssm-documents` package adds support for newer python runtimes. 
+### Security
+- Upgraded cross-spawn to mitigate [CVE-2024-21538](https://avd.aquasec.com/nvd/cve-2024-21538)
+
 ## [2.1.3] - 2024-09-18
 
 ### Fixed

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -181,6 +181,8 @@ main() {
     mv "$template_dist_dir"/MemberRoleStack.template "$template_dist_dir"/aws-sharr-member-roles.template
 
     rm "$template_dist_dir"/*.nested.template
+
+    python3 $template_dir/upgrade_python_runtimes.py $template_dist_dir/playbooks
 }
 
 main "$@"

--- a/deployment/upgrade_python_runtimes.py
+++ b/deployment/upgrade_python_runtimes.py
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# !/usr/bin/env python3
+
+import json
+import os
+import re
+import sys
+
+
+def update_python_runtimes(directory):
+    """
+    The @cdklabs/cdk-ssm-documents package used to create some of the solution's control runbooks (SSM Documents)
+    does not support python runtimes newer than python3.8 as of 11/14/2024. This function updates all member runbook templates
+    to use python3.11 instead of python3.8 after they are synthesized.
+    :param directory: directory where synthesized templates are located.
+    """
+    for template_filename in os.listdir(directory):
+        if re.search(r"MemberStack(\d*).template$", template_filename):
+            file_path = os.path.join(directory, template_filename)
+
+            with open(file_path, "r") as file:
+                try:
+                    data = json.load(file)
+                except json.JSONDecodeError:
+                    print(f"Skipping {template_filename}: not a valid JSON file.")
+                    continue
+            # Convert template JSON to string and replace "python3.8" with "python3.11"
+            template_str = json.dumps(data)
+            updated_template_str = template_str.replace("python3.8", "python3.11")
+            updated_template = json.loads(updated_template_str)
+            # Write the updated template back to the .template file
+            with open(file_path, "w") as file:
+                json.dump(updated_template, file, indent=1)
+            print(
+                f"Successfully updated python runtimes in {template_filename} from python3.8 --> python3.11"
+            )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(
+            "Invalid invocation. Script should be invoked like: python upgrade_python_runtimes.py <directory_path>"
+        )
+        sys.exit(1)
+    directory_path = sys.argv[1]
+    update_python_runtimes(directory_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automated_security_response_on_aws"
-version = "2.1.3"
+version = "2.1.4"
 
 [tool.setuptools]
 package-dir = {"" = "source"}

--- a/solution-manifest.yaml
+++ b/solution-manifest.yaml
@@ -1,6 +1,6 @@
 id: SO0111
 name: security-hub-automated-response-and-remediation
-version: 2.1.3
+version: 2.1.4
 cloudformation_templates:
   - template: aws-sharr-deploy.template
     main_template: true

--- a/source/lib/__snapshots__/member-stack.test.ts.snap
+++ b/source/lib/__snapshots__/member-stack.test.ts.snap
@@ -1265,6 +1265,14 @@ exports[`member stack snapshot matches 1`] = `
       "DependsOn": [
         "WaitProviderRole83B0295F",
       ],
+      "Metadata": {
+        "guard": {
+          "SuppressedRules": [
+            "LAMBDA_CONCURRENCY_CHECK",
+            "LAMBDA_INSIDE_VPC",
+          ],
+        },
+      },
       "Properties": {
         "Code": {
           "S3Bucket": {
@@ -1305,6 +1313,12 @@ exports[`member stack snapshot matches 1`] = `
               "id": "AwsSolutions-IAM5",
               "reason": "Resource * is needed for CloudWatch Logs policies used on Lambda functions.",
             },
+          ],
+        },
+        "guard": {
+          "SuppressedRules": [
+            "IAM_NO_INLINE_POLICY_CHECK",
+            "IAM_POLICYDOCUMENT_NO_WILDCARD_RESOURCE",
           ],
         },
       },

--- a/source/lib/cdk-helper/add-cfn-nag-suppression.ts
+++ b/source/lib/cdk-helper/add-cfn-nag-suppression.ts
@@ -24,3 +24,24 @@ export function addCfnNagSuppression(resource: IConstruct, suppression: CfnNagSu
     };
   }
 }
+
+export function addCfnGuardSuppression(resource: IConstruct, suppression: string): void {
+  const cfnResource = resource.node.defaultChild as CfnResource;
+  if (!cfnResource?.cfnOptions) {
+    throw new Error(`Resource ${cfnResource?.logicalId} has no cfnOptions, unable to add CfnGuard suppression`);
+  }
+  const existingSuppressions: string[] = cfnResource.cfnOptions.metadata?.guard?.SuppressedRules;
+  if (existingSuppressions) {
+    existingSuppressions.push(suppression);
+  } else if (cfnResource.cfnOptions.metadata) {
+    cfnResource.cfnOptions.metadata.guard = {
+      SuppressedRules: [suppression],
+    };
+  } else {
+    cfnResource.cfnOptions.metadata = {
+      guard: {
+        SuppressedRules: [suppression],
+      },
+    };
+  }
+}

--- a/source/lib/cloudwatch_metrics.ts
+++ b/source/lib/cloudwatch_metrics.ts
@@ -19,6 +19,7 @@ import { Topic } from 'aws-cdk-lib/aws-sns';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { addCfnGuardSuppression } from './cdk-helper/add-cfn-nag-suppression';
 
 export interface CloudWatchMetricsProps {
   solutionId: string;
@@ -195,6 +196,7 @@ export class CloudWatchMetrics {
     });
     setCondition(noRemediationErrorAlarm, isUsingCloudWatchMetricsAlarms);
     noRemediationErrorAlarm.addAlarmAction(new SnsAction(snsAlarmTopic));
+    addCfnGuardSuppression(noRemediationErrorAlarm, 'CFN_NO_EXPLICIT_RESOURCE_NAMES');
 
     const failedAssumeRoleAlarm = failedAssumeRoleMetric.createAlarm(scope, 'FailedAssumeRoleAlarm', {
       alarmName: 'ASR-RunbookAssumeRoleFailure',
@@ -210,6 +212,8 @@ export class CloudWatchMetrics {
     setCondition(failedAssumeRoleAlarm, isUsingCloudWatchMetricsAlarms);
     failedAssumeRoleAlarm.addAlarmAction(new SnsAction(snsAlarmTopic));
 
+    addCfnGuardSuppression(failedAssumeRoleAlarm, 'CFN_NO_EXPLICIT_RESOURCE_NAMES');
+
     const stateMachineExecutionsAlarm = stateMachineExecutionsMetric.createAlarm(scope, 'StateMachineExecutions', {
       alarmName: 'ASR-StateMachineExecutions',
       evaluationPeriods: 1,
@@ -222,6 +226,7 @@ export class CloudWatchMetrics {
 
     setCondition(stateMachineExecutionsAlarm, isUsingCloudWatchMetricsAlarms);
     stateMachineExecutionsAlarm.addAlarmAction(new SnsAction(snsAlarmTopic));
+    addCfnGuardSuppression(stateMachineExecutionsAlarm, 'CFN_NO_EXPLICIT_RESOURCE_NAMES');
 
     /// CloudWatch Dashboard
     const remediationDashboard = new Dashboard(scope, 'RemediationDashboard', {

--- a/source/lib/common-orchestrator-construct.ts
+++ b/source/lib/common-orchestrator-construct.ts
@@ -10,6 +10,7 @@ import { Construct } from 'constructs';
 import * as cdk_nag from 'cdk-nag';
 import { Timeout } from 'aws-cdk-lib/aws-stepfunctions';
 import { IQueue } from 'aws-cdk-lib/aws-sqs';
+import { addCfnGuardSuppression } from './cdk-helper/add-cfn-nag-suppression';
 
 export interface ConstructProps {
   roleArn: string;
@@ -494,6 +495,7 @@ export class OrchestratorConstruct extends Construct {
           'CloudWatch Logs permissions require resource * except for DescribeLogGroups, except for GovCloud, which only works with resource *',
       },
     ]);
+    addCfnGuardSuppression(orchestratorRole, 'IAM_NO_INLINE_POLICY_CHECK');
 
     const orchestratorStateMachine = new sfn.StateMachine(this, 'StateMachine', {
       definitionBody: sfn.DefinitionBody.fromChainable(extractFindings),

--- a/source/lib/orchestrator_roles-construct.ts
+++ b/source/lib/orchestrator_roles-construct.ts
@@ -12,6 +12,7 @@ import {
   CfnRole,
 } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
+import { addCfnGuardSuppression } from './cdk-helper/add-cfn-nag-suppression';
 
 export interface OrchRoleProps {
   solutionId: string;
@@ -142,5 +143,6 @@ export class OrchestratorMemberRole extends Construct {
         ],
       },
     };
+    addCfnGuardSuppression(memberRole, 'IAM_NO_INLINE_POLICY_CHECK');
   }
 }

--- a/source/lib/remediation_runbook-stack.ts
+++ b/source/lib/remediation_runbook-stack.ts
@@ -25,6 +25,7 @@ import { SsmRole } from './ssmplaybook';
 import { Aspects, CfnParameter } from 'aws-cdk-lib';
 import { WaitProvider } from './wait-provider';
 import SsmDocRateLimit from './ssm-doc-rate-limit';
+import { addCfnGuardSuppression } from './cdk-helper/add-cfn-nag-suppression';
 
 export interface MemberRoleStackProps extends cdk.StackProps {
   readonly solutionId: string;
@@ -419,6 +420,7 @@ export class RemediationRunbookStack extends cdk.Stack {
           },
         };
       }
+      addCfnGuardSuppression(ctcw_remediation_role, 'IAM_NO_INLINE_POLICY_CHECK');
     }
     //-----------------------
     // EnableCloudTrailEncryption
@@ -600,6 +602,7 @@ export class RemediationRunbookStack extends cdk.Stack {
           ],
         },
       };
+      addCfnGuardSuppression(remediation_role, 'IAM_NO_INLINE_POLICY_CHECK');
 
       new SsmRole(props.roleStack, 'RemediationRole ' + remediationName, {
         solutionId: props.solutionId,

--- a/source/lib/sns2-remediation-resources.ts
+++ b/source/lib/sns2-remediation-resources.ts
@@ -4,6 +4,7 @@ import * as cdk_nag from 'cdk-nag';
 import * as cdk from 'aws-cdk-lib';
 import { Effect, Policy, PolicyStatement, Role, ServicePrincipal, CfnRole } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
+import { addCfnGuardSuppression } from './cdk-helper/add-cfn-nag-suppression';
 
 export interface ISNS2DeliveryStatusLoggingRole {
   roleName: string;
@@ -66,5 +67,6 @@ export class SNS2DeliveryStatusLoggingRole extends Construct {
         ],
       },
     };
+    addCfnGuardSuppression(deliveryStatusLoggingRole, 'CFN_NO_EXPLICIT_RESOURCE_NAMES');
   }
 }

--- a/source/lib/wait-provider.ts
+++ b/source/lib/wait-provider.ts
@@ -6,6 +6,7 @@ import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
+import { addCfnGuardSuppression } from './cdk-helper/add-cfn-nag-suppression';
 
 export interface WaitProviderProps {
   readonly serviceToken: string;
@@ -67,6 +68,8 @@ export class WaitProvider extends Construct {
       assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
       inlinePolicies: { LambdaPolicy: policyDocument },
     });
+    addCfnGuardSuppression(role, 'IAM_NO_INLINE_POLICY_CHECK');
+    addCfnGuardSuppression(role, 'IAM_POLICYDOCUMENT_NO_WILDCARD_RESOURCE');
 
     NagSuppressions.addResourceSuppressions(role, [
       {
@@ -87,6 +90,8 @@ export class WaitProvider extends Construct {
       environment: { LOG_LEVEL: 'INFO' },
       timeout: Duration.minutes(15),
     });
+    addCfnGuardSuppression(lambdaFunction, 'LAMBDA_CONCURRENCY_CHECK');
+    addCfnGuardSuppression(lambdaFunction, 'LAMBDA_INSIDE_VPC');
 
     return new WaitProvider(scope, id, { serviceToken: lambdaFunction.functionArn });
   }

--- a/source/package-lock.json
+++ b/source/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "automated-security-response-on-aws",
-    "version": "2.1.3",
+    "name": "aws-security-hub-automated-response-and-remediation",
+    "version": "2.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "automated-security-response-on-aws",
-            "version": "2.1.3",
+            "name": "aws-security-hub-automated-response-and-remediation",
+            "version": "2.1.4",
             "license": "Apache-2.0",
             "bin": {
                 "solution_deploy": "bin/solution_deploy.js"
@@ -3477,9 +3477,9 @@
             "dev": true
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -10148,9 +10148,9 @@
             "dev": true
         },
         "cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "requires": {
                 "path-key": "^3.1.0",

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-security-hub-automated-response-and-remediation",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "Automated remediation for AWS Security Hub (SO0111)",
     "bin": {
         "solution_deploy": "bin/solution_deploy.js"

--- a/source/test/__snapshots__/orchestrator.test.ts.snap
+++ b/source/test/__snapshots__/orchestrator.test.ts.snap
@@ -178,6 +178,11 @@ exports[`test App Orchestrator Construct 1`] = `
             },
           ],
         },
+        "guard": {
+          "SuppressedRules": [
+            "IAM_NO_INLINE_POLICY_CHECK",
+          ],
+        },
       },
       "Properties": {
         "AssumeRolePolicyDocument": {

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -25,6 +25,11 @@ exports[`Global Roles Stack 1`] = `
             },
           ],
         },
+        "guard": {
+          "SuppressedRules": [
+            "IAM_NO_INLINE_POLICY_CHECK",
+          ],
+        },
       },
       "Properties": {
         "AssumeRolePolicyDocument": {

--- a/source/test/__snapshots__/solution_deploy.test.ts.snap
+++ b/source/test/__snapshots__/solution_deploy.test.ts.snap
@@ -311,6 +311,14 @@ exports[`Test if the Stack has all the resources. 1`] = `
       "DependsOn": [
         "stackRole9B4D53CC",
       ],
+      "Metadata": {
+        "guard": {
+          "SuppressedRules": [
+            "LAMBDA_INSIDE_VPC",
+            "LAMBDA_CONCURRENCY_CHECK",
+          ],
+        },
+      },
       "Properties": {
         "Code": {
           "S3Bucket": "solutions-eu-west-1",
@@ -674,6 +682,13 @@ exports[`Test if the Stack has all the resources. 1`] = `
     },
     "FailedAssumeRoleAlarm06397028": {
       "Condition": "isUsingCloudWatchMetricsAlarms",
+      "Metadata": {
+        "guard": {
+          "SuppressedRules": [
+            "CFN_NO_EXPLICIT_RESOURCE_NAMES",
+          ],
+        },
+      },
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
@@ -708,6 +723,13 @@ exports[`Test if the Stack has all the resources. 1`] = `
     },
     "NoRemediationErrorAlarm20FFD8DF": {
       "Condition": "isUsingCloudWatchMetricsAlarms",
+      "Metadata": {
+        "guard": {
+          "SuppressedRules": [
+            "CFN_NO_EXPLICIT_RESOURCE_NAMES",
+          ],
+        },
+      },
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
@@ -1505,6 +1527,14 @@ exports[`Test if the Stack has all the resources. 1`] = `
     },
     "SchedulingTable1EC09B43": {
       "DeletionPolicy": "Retain",
+      "Metadata": {
+        "guard": {
+          "SuppressedRules": [
+            "DYNAMODB_BILLING_MODE_RULE",
+            "DYNAMODB_TABLE_ENCRYPTED_KMS",
+          ],
+        },
+      },
       "Properties": {
         "AttributeDefinitions": [
           {
@@ -1552,6 +1582,13 @@ exports[`Test if the Stack has all the resources. 1`] = `
     },
     "StateMachineExecutions0993FE1A": {
       "Condition": "isUsingCloudWatchMetricsAlarms",
+      "Metadata": {
+        "guard": {
+          "SuppressedRules": [
+            "CFN_NO_EXPLICIT_RESOURCE_NAMES",
+          ],
+        },
+      },
       "Properties": {
         "AlarmActions": [
           {
@@ -2254,6 +2291,11 @@ exports[`Test if the Stack has all the resources. 1`] = `
             },
           ],
         },
+        "guard": {
+          "SuppressedRules": [
+            "IAM_NO_INLINE_POLICY_CHECK",
+          ],
+        },
       },
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -2490,6 +2532,11 @@ exports[`Test if the Stack has all the resources. 1`] = `
             },
           ],
         },
+        "guard": {
+          "SuppressedRules": [
+            "IAM_NO_INLINE_POLICY_CHECK",
+          ],
+        },
       },
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -2661,6 +2708,13 @@ exports[`Test if the Stack has all the resources. 1`] = `
         "SchedulingLambdaRoleDefaultPolicy73C1B49B",
         "SchedulingLambdaRoleAB00F55C",
       ],
+      "Metadata": {
+        "guard": {
+          "SuppressedRules": [
+            "LAMBDA_INSIDE_VPC",
+          ],
+        },
+      },
       "Properties": {
         "Code": {
           "S3Bucket": "solutions-eu-west-1",
@@ -2775,6 +2829,12 @@ exports[`Test if the Stack has all the resources. 1`] = `
               "id": "AwsSolutions-IAM5",
               "reason": "Resource * is needed for CloudWatch Logs policies used on Lambda functions.",
             },
+          ],
+        },
+        "guard": {
+          "SuppressedRules": [
+            "IAM_NO_INLINE_POLICY_CHECK",
+            "IAM_POLICYDOCUMENT_NO_WILDCARD_RESOURCE",
           ],
         },
       },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
## [2.1.4] - 2024-11-18
### Changed
- Upgraded python runtimes in all control runbooks from python3.8 to python3.11.
  - Upgrade is done at build-time temporarily, until the `cdklabs/cdk-ssm-documents` package adds support for newer python runtimes. 
### Security
- Upgraded cross-spawn to mitigate [CVE-2024-21538](https://avd.aquasec.com/nvd/cve-2024-21538)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.