### PR TITLE
fix: #226 - fix import references for python files in layer module in Lambda Layer

### DIFF
--- a/source/layer/applogger.py
+++ b/source/layer/applogger.py
@@ -12,7 +12,7 @@ import time
 from datetime import date
 
 from botocore.exceptions import ClientError
-from layer import awsapi_cached_client
+from . import awsapi_cached_client
 
 LOG_MAX_BATCH_SIZE = 1048576  # Controls when the buffer is flushed to the stream
 LOG_ENTRY_ADDITIONAL = 26

--- a/source/layer/cloudwatch_metrics.py
+++ b/source/layer/cloudwatch_metrics.py
@@ -4,7 +4,7 @@ import os
 from typing import TYPE_CHECKING, Any, cast
 
 import boto3
-from layer.logger import Logger
+from .logger import Logger
 
 if TYPE_CHECKING:
     from mypy_boto3_cloudwatch import CloudWatchClient

--- a/source/layer/metrics.py
+++ b/source/layer/metrics.py
@@ -9,7 +9,7 @@ from urllib.request import Request, urlopen
 
 import boto3
 from botocore.exceptions import ClientError
-from layer import awsapi_cached_client
+from . import awsapi_cached_client
 
 if TYPE_CHECKING:
     from mypy_boto3_ssm.client import SSMClient

--- a/source/layer/sechub_findings.py
+++ b/source/layer/sechub_findings.py
@@ -6,8 +6,8 @@ import os
 from typing import Any, Union
 
 from botocore.exceptions import ClientError
-from layer.awsapi_cached_client import AWSCachedClient
-from layer.utils import publish_to_sns
+from .awsapi_cached_client import AWSCachedClient
+from .utils import publish_to_sns
 
 # Get AWS region from Lambda environment. If not present then we're not
 # running under lambda, so defaulting to us-east-1

--- a/source/layer/utils.py
+++ b/source/layer/utils.py
@@ -7,8 +7,8 @@ from typing import Any
 
 import boto3
 from botocore.exceptions import UnknownRegionError
-from layer.awsapi_cached_client import AWSCachedClient
-from layer.logger import Logger
+from .awsapi_cached_client import AWSCachedClient
+from .logger import Logger
 
 AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
 


### PR DESCRIPTION
*Issue #226*

*Description of changes:*

Change python scripts inside layer module in the Lambda Layer to use `.` instead of `layer.` references on import.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.